### PR TITLE
Used hamcrest matcher "notNullValue"

### DIFF
--- a/app/src/test/java/com/husseinelfeky/moviesexplorer/master/MasterViewModelTest.kt
+++ b/app/src/test/java/com/husseinelfeky/moviesexplorer/master/MasterViewModelTest.kt
@@ -11,6 +11,7 @@ import com.husseinelfeky.moviesexplorer.utils.MainCoroutineRule
 import com.husseinelfeky.moviesexplorer.utils.getOrAwaitValue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.hamcrest.CoreMatchers.`is`
+import org.hamcrest.CoreMatchers.notNullValue
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Before
 import org.junit.Rule
@@ -67,7 +68,8 @@ class MainViewModelTest : AutoCloseKoinTest() {
         val result = viewModel.getAllMovies().getOrAwaitValue()
 
         // THEN - Verify that movies exist and are fetched successfully.
-        assertThat(result.isNullOrEmpty(), `is`(false))
+        assertThat(result, `is`(notNullValue()))
+        assertThat(result.size, `is`(0))
     }
 
     @Test
@@ -80,7 +82,8 @@ class MainViewModelTest : AutoCloseKoinTest() {
 
         // THEN - Verify that search results are found and contain 8 differentiable items
         // (2 years and 6 movies).
-        assertThat(result.isNullOrEmpty(), `is`(false))
+        assertThat(result, `is`(notNullValue()))
+
         assertThat(result.size, `is`(8))
 
         var expectedMoviesCount = 6

--- a/app/src/test/java/com/husseinelfeky/moviesexplorer/master/MasterViewModelTest.kt
+++ b/app/src/test/java/com/husseinelfeky/moviesexplorer/master/MasterViewModelTest.kt
@@ -11,7 +11,6 @@ import com.husseinelfeky.moviesexplorer.utils.MainCoroutineRule
 import com.husseinelfeky.moviesexplorer.utils.getOrAwaitValue
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.hamcrest.CoreMatchers.`is`
-import org.hamcrest.CoreMatchers.notNullValue
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Before
 import org.junit.Rule

--- a/app/src/test/java/com/husseinelfeky/moviesexplorer/master/MasterViewModelTest.kt
+++ b/app/src/test/java/com/husseinelfeky/moviesexplorer/master/MasterViewModelTest.kt
@@ -82,8 +82,6 @@ class MainViewModelTest : AutoCloseKoinTest() {
 
         // THEN - Verify that search results are found and contain 8 differentiable items
         // (2 years and 6 movies).
-        assertThat(result, `is`(notNullValue()))
-
         assertThat(result.size, `is`(8))
 
         var expectedMoviesCount = 6


### PR DESCRIPTION
Using the **notNullValue** hamcrest matcher in the test is more preferable than using **isNullOrEmpty** to check the list content